### PR TITLE
further reduce GC, define sentence starters in language modules

### DIFF
--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -5,8 +5,6 @@ module PragmaticSegmenter
   # replaces the periods.
   class AbbreviationReplacer
 
-    SENTENCE_STARTERS = %w(A Being Did For He How However I In It Millions More She That The There They We What When Where Who Why)
-
     attr_reader :text
     def initialize(text:, language: )
       @text = Text.new(text)
@@ -75,7 +73,7 @@ module PragmaticSegmenter
       # and try to cover the words that most often start a
       # sentence but could never follow one of the abbreviations below.
 
-      SENTENCE_STARTERS.each do |word|
+      @language::AbbreviationReplacer::SENTENCE_STARTERS.each do |word|
         escaped = Regexp.escape(word)
         txt.gsub!(/U∯S∯\s#{escaped}\s/, "U∯S\.\s#{escaped}\s")
         txt.gsub!(/U\.S∯\s#{escaped}\s/, "U\.S\.\s#{escaped}\s")

--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -76,17 +76,18 @@ module PragmaticSegmenter
       # sentence but could never follow one of the abbreviations below.
 
       SENTENCE_STARTERS.each do |word|
-        txt.gsub!(/U∯S∯\s#{Regexp.escape(word)}\s/, "U∯S\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/U\.S∯\s#{Regexp.escape(word)}\s/, "U\.S\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/U∯K∯\s#{Regexp.escape(word)}\s/, "U∯K\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/U\.K∯\s#{Regexp.escape(word)}\s/, "U\.K\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/E∯U∯\s#{Regexp.escape(word)}\s/, "E∯U\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/E\.U∯\s#{Regexp.escape(word)}\s/, "E\.U\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/U∯S∯A∯\s#{Regexp.escape(word)}\s/, "U∯S∯A\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/U\.S\.A∯\s#{Regexp.escape(word)}\s/, "U\.S\.A\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/I∯\s#{Regexp.escape(word)}\s/, "I\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/i.v∯\s#{Regexp.escape(word)}\s/, "i\.v\.\s#{Regexp.escape(word)}\s")
-        txt.gsub!(/I.V∯\s#{Regexp.escape(word)}\s/, "I\.V\.\s#{Regexp.escape(word)}\s")
+        escaped = Regexp.escape(word)
+        txt.gsub!(/U∯S∯\s#{escaped}\s/, "U∯S\.\s#{escaped}\s")
+        txt.gsub!(/U\.S∯\s#{escaped}\s/, "U\.S\.\s#{escaped}\s")
+        txt.gsub!(/U∯K∯\s#{escaped}\s/, "U∯K\.\s#{escaped}\s")
+        txt.gsub!(/U\.K∯\s#{escaped}\s/, "U\.K\.\s#{escaped}\s")
+        txt.gsub!(/E∯U∯\s#{escaped}\s/, "E∯U\.\s#{escaped}\s")
+        txt.gsub!(/E\.U∯\s#{escaped}\s/, "E\.U\.\s#{escaped}\s")
+        txt.gsub!(/U∯S∯A∯\s#{escaped}\s/, "U∯S∯A\.\s#{escaped}\s")
+        txt.gsub!(/U\.S\.A∯\s#{escaped}\s/, "U\.S\.A\.\s#{escaped}\s")
+        txt.gsub!(/I∯\s#{escaped}\s/, "I\.\s#{escaped}\s")
+        txt.gsub!(/i.v∯\s#{escaped}\s/, "i\.v\.\s#{escaped}\s")
+        txt.gsub!(/I.V∯\s#{escaped}\s/, "I\.V\.\s#{escaped}\s")
       end
       txt
     end

--- a/lib/pragmatic_segmenter/languages/common.rb
+++ b/lib/pragmatic_segmenter/languages/common.rb
@@ -97,6 +97,11 @@ module PragmaticSegmenter
       ExtraWhiteSpaceRule = Rule.new(/\s{3,}/, ' ')
 
       SubSingleQuoteRule = Rule.new(/&⎋&/, "'")
+
+      class AbbreviationReplacer < AbbreviationReplacer
+        SENTENCE_STARTERS = [].freeze
+      end
+
     end
   end
 end

--- a/lib/pragmatic_segmenter/languages/deutsch.rb
+++ b/lib/pragmatic_segmenter/languages/deutsch.rb
@@ -59,6 +59,12 @@ module PragmaticSegmenter
       end
 
       class AbbreviationReplacer  < AbbreviationReplacer
+
+        SENTENCE_STARTERS = %w(
+          Am Auch Auf Bei Da Das Der Die Ein Eine Es Für Heute Ich Im In
+          Ist Jetzt Mein Mit Nach So Und Warum Was Wenn Wer Wie Wir
+        ).freeze
+
         def replace
           @text = text.apply(
             @language::PossessiveAbbreviationRule,

--- a/lib/pragmatic_segmenter/languages/english.rb
+++ b/lib/pragmatic_segmenter/languages/english.rb
@@ -19,6 +19,13 @@ module PragmaticSegmenter
           []
         end
       end
+
+      class AbbreviationReplacer < AbbreviationReplacer
+        SENTENCE_STARTERS = %w(
+          A Being Did For He How However I In It Millions More She That The
+          There They We What When Where Who Why
+        ).freeze
+      end
     end
   end
 end


### PR DESCRIPTION
Two changes:
 1. As `Regexp.escape(word)` creates a new string each time, it's better to only run it once per iteration. I assume there's more GC reduction possible, but this and the previous change seem to be the lowest-hanging fruits.
 2. `SENTENCE_STARTERS` are now defined in their language submodules. I've kept the english sentence starters array, queried my db of a few million tweets in German for the most frequent sentence starters and added these to the german module. Certainly we'd have other words when using a more eloquent source. – Other languages will have to deal with an empty array of sentence starters.