### PR TITLE
Refactored 'remove_newline_in_middle_of_sentence'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
-gem 'codeclimate-test-reporter', group: :test, require: nil
+group :test do
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter'
+end
 # Specify your gem's dependencies in pragmatic_segmenter.gemspec
 gemspec

--- a/lib/pragmatic_segmenter/cleaner.rb
+++ b/lib/pragmatic_segmenter/cleaner.rb
@@ -83,11 +83,8 @@ module PragmaticSegmenter
     end
 
     def remove_newline_in_middle_of_sentence
-      @text.dup.gsub!(/(?:[^\.])*/) do |match|
-        next unless match.include?("\n")
-        orig = match.dup
-        match.gsub!(NEWLINE_IN_MIDDLE_OF_SENTENCE_REGEX, '')
-        @text.gsub!(/#{Regexp.escape(orig)}/, "#{match}")
+      @text.gsub!(/(?:[^\.])*/) do |match|
+        match.gsub(NEWLINE_IN_MIDDLE_OF_SENTENCE_REGEX, '')
       end
       @text
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 require 'pragmatic_segmenter'
 


### PR DESCRIPTION
I had an issue where this method ended doing infinite substitutions to the string - resulting in `NoMemoryError` or computer crash.

It is now refactored. `Gemfile` and `spec_helper.rb` were edited per instructions in https://github.com/codeclimate/ruby-test-reporter.