### PR TITLE
reducing object allocations

### DIFF
--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -30,11 +30,12 @@ module PragmaticSegmenter
     def search_for_abbreviations_in_string(txt)
       original = txt.dup
       downcased = Unicode::downcase(txt)
-      @language::Abbreviation::ABBREVIATIONS.each do |a|
-        next unless downcased.include?(a.strip)
-        abbrev_match = original.scan(/(?:^|\s|\r|\n)#{Regexp.escape(a.strip)}/i)
+      @language::Abbreviation::ABBREVIATIONS.each do |abbreviation|
+        stripped = abbreviation.strip
+        next unless downcased.include?(stripped)
+        abbrev_match = original.scan(/(?:^|\s|\r|\n)#{Regexp.escape(stripped)}/i)
         next if abbrev_match.empty?
-        next_word_start = /(?<=#{Regexp.escape(a.strip)} ).{1}/
+        next_word_start = /(?<=#{Regexp.escape(stripped)} ).{1}/
         character_array = @text.scan(next_word_start)
         abbrev_match.each_with_index do |am, index|
           txt = scan_for_replacements(txt, am, index, character_array)

--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -76,19 +76,11 @@ module PragmaticSegmenter
       # and try to cover the words that most often start a
       # sentence but could never follow one of the abbreviations below.
 
+      # Rubular: http://rubular.com/r/PkBQ3PVBS8
       @language::AbbreviationReplacer::SENTENCE_STARTERS.each do |word|
         escaped = Regexp.escape(word)
-        txt.gsub!(/U∯S∯\s#{escaped}\s/, "U∯S\.\s#{escaped}\s")
-        txt.gsub!(/U\.S∯\s#{escaped}\s/, "U\.S\.\s#{escaped}\s")
-        txt.gsub!(/U∯K∯\s#{escaped}\s/, "U∯K\.\s#{escaped}\s")
-        txt.gsub!(/U\.K∯\s#{escaped}\s/, "U\.K\.\s#{escaped}\s")
-        txt.gsub!(/E∯U∯\s#{escaped}\s/, "E∯U\.\s#{escaped}\s")
-        txt.gsub!(/E\.U∯\s#{escaped}\s/, "E\.U\.\s#{escaped}\s")
-        txt.gsub!(/U∯S∯A∯\s#{escaped}\s/, "U∯S∯A\.\s#{escaped}\s")
-        txt.gsub!(/U\.S\.A∯\s#{escaped}\s/, "U\.S\.A\.\s#{escaped}\s")
-        txt.gsub!(/I∯\s#{escaped}\s/, "I\.\s#{escaped}\s")
-        txt.gsub!(/i.v∯\s#{escaped}\s/, "i\.v\.\s#{escaped}\s")
-        txt.gsub!(/I.V∯\s#{escaped}\s/, "I\.V\.\s#{escaped}\s")
+        regex   = /(U∯S|U\.S|U∯K|E∯U|E\.U|U∯S∯A|U\.S\.A|I|i.v|I.V)∯(?=\s#{escaped}\s)/
+        txt.gsub!(regex, '\1.')
       end
       txt
     end

--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'unicode'
 
 module PragmaticSegmenter

--- a/lib/pragmatic_segmenter/between_punctuation.rb
+++ b/lib/pragmatic_segmenter/between_punctuation.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module PragmaticSegmenter
   # This class searches for punctuation between quotes or parenthesis

--- a/lib/pragmatic_segmenter/cleaner.rb
+++ b/lib/pragmatic_segmenter/cleaner.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require_relative 'cleaner/rules'
 
 module PragmaticSegmenter

--- a/lib/pragmatic_segmenter/cleaner.rb
+++ b/lib/pragmatic_segmenter/cleaner.rb
@@ -64,7 +64,7 @@ module PragmaticSegmenter
 
     def replace_punctuation_in_brackets
       @text.dup.gsub!(/\[(?:[^\]])*\]/) do |match|
-        @text.gsub!(/#{Regexp.escape(match)}/, "#{match.dup.gsub!(/\?/, '&ᓷ&')}") if match.include?('?')
+        @text.gsub!(/#{Regexp.escape(match)}/, match.dup.gsub!(/\?/, '&ᓷ&')) if match.include?('?')
       end
     end
 

--- a/lib/pragmatic_segmenter/cleaner/rules.rb
+++ b/lib/pragmatic_segmenter/cleaner/rules.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   # This is an opinionated class that removes errant newlines,
   # xhtml, inline formatting, etc.

--- a/lib/pragmatic_segmenter/exclamation_words.rb
+++ b/lib/pragmatic_segmenter/exclamation_words.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'pragmatic_segmenter/punctuation_replacer'
 
 module PragmaticSegmenter

--- a/lib/pragmatic_segmenter/exclamation_words.rb
+++ b/lib/pragmatic_segmenter/exclamation_words.rb
@@ -7,15 +7,14 @@ module PragmaticSegmenter
   # This class searches for exclamation points that
   # are part of words and not ending punctuation and replaces them.
   module ExclamationWords
-    WORDS_WITH_EXCLAMATIONS = ['!Xũ', '!Kung', 'ǃʼOǃKung', '!Xuun', '!Kung-Ekoka', 'ǃHu', 'ǃKhung', 'ǃKu', 'ǃung', 'ǃXo', 'ǃXû', 'ǃXung', 'ǃXũ', '!Xun', 'Yahoo!', 'Y!J', 'Yum!']
+    EXCLAMATION_WORDS = %w[!Xũ !Kung ǃʼOǃKung !Xuun !Kung-Ekoka ǃHu ǃKhung ǃKu ǃung ǃXo ǃXû ǃXung ǃXũ !Xun Yahoo! Y!J Yum!].freeze
+    REGEXP            = Regexp.new(EXCLAMATION_WORDS.map { |string| Regexp.escape(string) }.join('|'))
 
     def self.apply_rules(text)
-      WORDS_WITH_EXCLAMATIONS.each do |exclamation|
-        PragmaticSegmenter::PunctuationReplacer.new(
-          matches_array: text.scan(/#{Regexp.escape(exclamation)}/),
-          text: text
-        ).replace
-      end
+      PragmaticSegmenter::PunctuationReplacer.new(
+        matches_array: text.scan(REGEXP),
+        text: text
+      ).replace
     end
   end
 end

--- a/lib/pragmatic_segmenter/languages.rb
+++ b/lib/pragmatic_segmenter/languages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pragmatic_segmenter/types'
 require 'pragmatic_segmenter/processor'
 require 'pragmatic_segmenter/cleaner'

--- a/lib/pragmatic_segmenter/languages/amharic.rb
+++ b/lib/pragmatic_segmenter/languages/amharic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Amharic

--- a/lib/pragmatic_segmenter/languages/arabic.rb
+++ b/lib/pragmatic_segmenter/languages/arabic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Arabic

--- a/lib/pragmatic_segmenter/languages/armenian.rb
+++ b/lib/pragmatic_segmenter/languages/armenian.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Armenian

--- a/lib/pragmatic_segmenter/languages/bulgarian.rb
+++ b/lib/pragmatic_segmenter/languages/bulgarian.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Bulgarian

--- a/lib/pragmatic_segmenter/languages/burmese.rb
+++ b/lib/pragmatic_segmenter/languages/burmese.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Burmese

--- a/lib/pragmatic_segmenter/languages/chinese.rb
+++ b/lib/pragmatic_segmenter/languages/chinese.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Chinese

--- a/lib/pragmatic_segmenter/languages/common.rb
+++ b/lib/pragmatic_segmenter/languages/common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'common/numbers'
 require_relative 'common/ellipsis'
 

--- a/lib/pragmatic_segmenter/languages/common/ellipsis.rb
+++ b/lib/pragmatic_segmenter/languages/common/ellipsis.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module PragmaticSegmenter
   module Languages

--- a/lib/pragmatic_segmenter/languages/common/numbers.rb
+++ b/lib/pragmatic_segmenter/languages/common/numbers.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module PragmaticSegmenter
   module Languages

--- a/lib/pragmatic_segmenter/languages/danish.rb
+++ b/lib/pragmatic_segmenter/languages/danish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Danish

--- a/lib/pragmatic_segmenter/languages/deutsch.rb
+++ b/lib/pragmatic_segmenter/languages/deutsch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Deutsch

--- a/lib/pragmatic_segmenter/languages/dutch.rb
+++ b/lib/pragmatic_segmenter/languages/dutch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Dutch

--- a/lib/pragmatic_segmenter/languages/english.rb
+++ b/lib/pragmatic_segmenter/languages/english.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module English

--- a/lib/pragmatic_segmenter/languages/french.rb
+++ b/lib/pragmatic_segmenter/languages/french.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module French

--- a/lib/pragmatic_segmenter/languages/greek.rb
+++ b/lib/pragmatic_segmenter/languages/greek.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Greek

--- a/lib/pragmatic_segmenter/languages/hindi.rb
+++ b/lib/pragmatic_segmenter/languages/hindi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Hindi

--- a/lib/pragmatic_segmenter/languages/italian.rb
+++ b/lib/pragmatic_segmenter/languages/italian.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Italian

--- a/lib/pragmatic_segmenter/languages/japanese.rb
+++ b/lib/pragmatic_segmenter/languages/japanese.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Japanese

--- a/lib/pragmatic_segmenter/languages/persian.rb
+++ b/lib/pragmatic_segmenter/languages/persian.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Persian

--- a/lib/pragmatic_segmenter/languages/polish.rb
+++ b/lib/pragmatic_segmenter/languages/polish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Polish

--- a/lib/pragmatic_segmenter/languages/russian.rb
+++ b/lib/pragmatic_segmenter/languages/russian.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Russian

--- a/lib/pragmatic_segmenter/languages/spanish.rb
+++ b/lib/pragmatic_segmenter/languages/spanish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Spanish

--- a/lib/pragmatic_segmenter/languages/urdu.rb
+++ b/lib/pragmatic_segmenter/languages/urdu.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   module Languages
     module Urdu

--- a/lib/pragmatic_segmenter/list.rb
+++ b/lib/pragmatic_segmenter/list.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module PragmaticSegmenter
   # This class searches for a list within a string and adds

--- a/lib/pragmatic_segmenter/list.rb
+++ b/lib/pragmatic_segmenter/list.rb
@@ -42,6 +42,10 @@ module PragmaticSegmenter
     ALPHABETICAL_LIST_LETTERS_AND_PERIODS_REGEX =
       /(?<=^)[a-z]\.|(?<=\A)[a-z]\.|(?<=\s)[a-z]\./i
 
+    # Rubular: http://rubular.com/r/GcnmQt4a3I
+    ROMAN_NUMERALS_IN_PARENTHESES =
+        /\(((?=[mdclxvi])m*(c[md]|d?c*)(x[cl]|l?x*)(i[xv]|v?i*))\)(?=\s[A-Z])/
+
     attr_reader :text
     def initialize(text:)
       @text = Text.new(text)
@@ -55,12 +59,7 @@ module PragmaticSegmenter
     end
 
     def replace_parens
-      ROMAN_NUMERALS.each do |rm|
-        next unless text =~ /\(#{Regexp.escape(rm)}\)\s[A-Z]/
-        text.gsub!(/\(#{Regexp.escape(rm)}\)(?=\s[A-Z])/) do |match|
-          match.gsub!(/\(/, '&✂&').gsub!(/\)/, '&⌬&')
-        end
-      end
+      text.gsub!(ROMAN_NUMERALS_IN_PARENTHESES, '&✂&\1&⌬&'.freeze)
       text
     end
 

--- a/lib/pragmatic_segmenter/processor.rb
+++ b/lib/pragmatic_segmenter/processor.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'pragmatic_segmenter/punctuation_replacer'
 require 'pragmatic_segmenter/between_punctuation'
 

--- a/lib/pragmatic_segmenter/punctuation_replacer.rb
+++ b/lib/pragmatic_segmenter/punctuation_replacer.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
 
 module PragmaticSegmenter
   # This class replaces punctuation that is typically a sentence boundary

--- a/lib/pragmatic_segmenter/punctuation_replacer.rb
+++ b/lib/pragmatic_segmenter/punctuation_replacer.rb
@@ -64,7 +64,7 @@ module PragmaticSegmenter
 
     def sub_characters(string, char_a, char_b)
       sub = string.gsub(char_a, char_b)
-      @text.gsub!(/#{Regexp.escape(string)}/, "#{sub}")
+      @text.gsub!(/#{Regexp.escape(string)}/, sub)
       sub
     end
   end

--- a/lib/pragmatic_segmenter/segmenter.rb
+++ b/lib/pragmatic_segmenter/segmenter.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'pragmatic_segmenter/languages'
 
 module PragmaticSegmenter

--- a/lib/pragmatic_segmenter/types.rb
+++ b/lib/pragmatic_segmenter/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   Rule = Struct.new(:pattern, :replacement)
 

--- a/lib/pragmatic_segmenter/version.rb
+++ b/lib/pragmatic_segmenter/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PragmaticSegmenter
   VERSION = "0.3.17"
 end


### PR DESCRIPTION
This pull request targets the lines of code that caused the highest number of object allocations in my specific use case. With these changes the allocated memory was reduced by two thirds (using `MemoryProfiler`), from 9MB to 3MB. It's a quick win, as in other use cases other parts of the code will require optimisation.