### PR TITLE
Feature/english test cases

### DIFF
--- a/lib/pragmatic_segmenter/between_punctuation.rb
+++ b/lib/pragmatic_segmenter/between_punctuation.rb
@@ -16,8 +16,6 @@ module PragmaticSegmenter
     # Rubular: http://rubular.com/r/x6s4PZK8jc
     BETWEEN_QUOTE_ARROW_REGEX = /«(?>[^»\\]+|\\{2}|\\.)*»/
 
-    BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX = /《(?>[^》\\]+|\\{2}|\\.)*》/
-
     # Rubular: http://rubular.com/r/JbAIpKdlSq
     BETWEEN_QUOTE_SLANTED_REGEX = /“(?>[^”\\]+|\\{2}|\\.)*”/
 
@@ -51,7 +49,6 @@ module PragmaticSegmenter
       sub_punctuation_between_square_brackets(txt)
       sub_punctuation_between_parens(txt)
       sub_punctuation_between_quotes_arrow(txt)
-      sub_punctuation_between_double_angled_quotation_marks(txt)
       sub_punctuation_between_em_dashes(txt)
       sub_punctuation_between_quotes_slanted(txt)
     end
@@ -101,13 +98,6 @@ module PragmaticSegmenter
     def sub_punctuation_between_quotes_arrow(txt)
       PragmaticSegmenter::PunctuationReplacer.new(
         matches_array: txt.scan(BETWEEN_QUOTE_ARROW_REGEX),
-        text: txt
-      ).replace
-    end
-
-    def sub_punctuation_between_double_angled_quotation_marks(txt)
-      PragmaticSegmenter::PunctuationReplacer.new(
-        matches_array: txt.scan(BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX),
         text: txt
       ).replace
     end

--- a/lib/pragmatic_segmenter/between_punctuation.rb
+++ b/lib/pragmatic_segmenter/between_punctuation.rb
@@ -16,6 +16,10 @@ module PragmaticSegmenter
     # Rubular: http://rubular.com/r/x6s4PZK8jc
     BETWEEN_QUOTE_ARROW_REGEX = /«(?>[^»\\]+|\\{2}|\\.)*»/
 
+    BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX = /《(?>[^》\\]+|\\{2}|\\.)*》/
+
+    BETWEEN_SINGLE_ANGLE_QUOTATION_MARK_REGEX = /〈(?>[^〉\\]+|\\{2}|\\.)*〉/
+
     # Rubular: http://rubular.com/r/JbAIpKdlSq
     BETWEEN_QUOTE_SLANTED_REGEX = /“(?>[^”\\]+|\\{2}|\\.)*”/
 
@@ -49,6 +53,8 @@ module PragmaticSegmenter
       sub_punctuation_between_square_brackets(txt)
       sub_punctuation_between_parens(txt)
       sub_punctuation_between_quotes_arrow(txt)
+      sub_punctuation_between_double_angled_quotation_marks(txt)
+      sub_punctuation_between_single_angled_quotation_marks(txt)
       sub_punctuation_between_em_dashes(txt)
       sub_punctuation_between_quotes_slanted(txt)
     end
@@ -98,6 +104,20 @@ module PragmaticSegmenter
     def sub_punctuation_between_quotes_arrow(txt)
       PragmaticSegmenter::PunctuationReplacer.new(
         matches_array: txt.scan(BETWEEN_QUOTE_ARROW_REGEX),
+        text: txt
+      ).replace
+    end
+
+    def sub_punctuation_between_double_angled_quotation_marks(txt)
+      PragmaticSegmenter::PunctuationReplacer.new(
+        matches_array: txt.scan(BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX),
+        text: txt
+      ).replace
+    end
+
+    def sub_punctuation_between_single_angled_quotation_marks(txt)
+      PragmaticSegmenter::PunctuationReplacer.new(
+        matches_array: txt.scan(BETWEEN_SINGLE_ANGLE_QUOTATION_MARK_REGEX),
         text: txt
       ).replace
     end

--- a/lib/pragmatic_segmenter/between_punctuation.rb
+++ b/lib/pragmatic_segmenter/between_punctuation.rb
@@ -8,6 +8,8 @@ module PragmaticSegmenter
     # Rubular: http://rubular.com/r/2YFrKWQUYi
     BETWEEN_SINGLE_QUOTES_REGEX = /(?<=\s)'(?:[^']|'[a-zA-Z])*'/
 
+    BETWEEN_SINGLE_QUOTE_SLANTED_REGEX = /(?<=\s)‘(?:[^’]|’[a-zA-Z])*’/
+
     # Rubular: http://rubular.com/r/3Pw1QlXOjd
     BETWEEN_DOUBLE_QUOTES_REGEX = /"(?>[^"\\]+|\\{2}|\\.)*"/
 
@@ -42,6 +44,7 @@ module PragmaticSegmenter
 
     def sub_punctuation_between_quotes_and_parens(txt)
       sub_punctuation_between_single_quotes(txt)
+      sub_punctuation_between_single_quote_slanted(txt)
       sub_punctuation_between_double_quotes(txt)
       sub_punctuation_between_square_brackets(txt)
       sub_punctuation_between_parens(txt)
@@ -72,6 +75,13 @@ module PragmaticSegmenter
           match_type: 'single'
         ).replace
       end
+    end
+
+    def sub_punctuation_between_single_quote_slanted(txt)
+      PragmaticSegmenter::PunctuationReplacer.new(
+        matches_array: txt.scan(BETWEEN_SINGLE_QUOTE_SLANTED_REGEX),
+        text: txt
+      ).replace
     end
 
     def sub_punctuation_between_double_quotes(txt)

--- a/lib/pragmatic_segmenter/between_punctuation.rb
+++ b/lib/pragmatic_segmenter/between_punctuation.rb
@@ -18,8 +18,6 @@ module PragmaticSegmenter
 
     BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX = /《(?>[^》\\]+|\\{2}|\\.)*》/
 
-    BETWEEN_SINGLE_ANGLE_QUOTATION_MARK_REGEX = /〈(?>[^〉\\]+|\\{2}|\\.)*〉/
-
     # Rubular: http://rubular.com/r/JbAIpKdlSq
     BETWEEN_QUOTE_SLANTED_REGEX = /“(?>[^”\\]+|\\{2}|\\.)*”/
 
@@ -54,7 +52,6 @@ module PragmaticSegmenter
       sub_punctuation_between_parens(txt)
       sub_punctuation_between_quotes_arrow(txt)
       sub_punctuation_between_double_angled_quotation_marks(txt)
-      sub_punctuation_between_single_angled_quotation_marks(txt)
       sub_punctuation_between_em_dashes(txt)
       sub_punctuation_between_quotes_slanted(txt)
     end
@@ -111,13 +108,6 @@ module PragmaticSegmenter
     def sub_punctuation_between_double_angled_quotation_marks(txt)
       PragmaticSegmenter::PunctuationReplacer.new(
         matches_array: txt.scan(BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX),
-        text: txt
-      ).replace
-    end
-
-    def sub_punctuation_between_single_angled_quotation_marks(txt)
-      PragmaticSegmenter::PunctuationReplacer.new(
-        matches_array: txt.scan(BETWEEN_SINGLE_ANGLE_QUOTATION_MARK_REGEX),
         text: txt
       ).replace
     end

--- a/lib/pragmatic_segmenter/languages/chinese.rb
+++ b/lib/pragmatic_segmenter/languages/chinese.rb
@@ -8,6 +8,32 @@ module PragmaticSegmenter
       class AbbreviationReplacer < AbbreviationReplacer
         SENTENCE_STARTERS = [].freeze
       end
+
+      class BetweenPunctuation < PragmaticSegmenter::BetweenPunctuation
+        BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX = /《(?>[^》\\]+|\\{2}|\\.)*》/
+        BETWEEN_L_BRACKET_REGEX = /「(?>[^」\\]+|\\{2}|\\.)*」/
+        private
+
+        def sub_punctuation_between_quotes_and_parens(txt)
+          super
+          sub_punctuation_between_double_angled_quotation_marks(txt)
+          sub_punctuation_between_l_bracket(txt)
+        end
+        
+        def sub_punctuation_between_double_angled_quotation_marks(txt)
+          PunctuationReplacer.new(
+            matches_array: txt.scan(BETWEEN_DOUBLE_ANGLE_QUOTATION_MARK_REGEX),
+            text: txt
+          ).replace
+        end
+        
+        def sub_punctuation_between_l_bracket(txt)
+          PunctuationReplacer.new(
+            matches_array: txt.scan(BETWEEN_L_BRACKET_REGEX),
+            text: txt
+          ).replace
+        end
+      end
     end
   end
 end

--- a/lib/pragmatic_segmenter/languages/common/numbers.rb
+++ b/lib/pragmatic_segmenter/languages/common/numbers.rb
@@ -76,10 +76,10 @@ module PragmaticSegmenter
       # replaces the periods.
       module SingleLetterAbbreviationRules
         # Rubular: http://rubular.com/r/e3H6kwnr6H
-        SingleUpperCaseLetterAtStartOfLineRule = Rule.new(/(?<=^[A-Z])\.(?=\s)/, '∯')
+        SingleUpperCaseLetterAtStartOfLineRule = Rule.new(/(?<=^[A-Z])\.(?=,?\s)/, '∯')
 
         # Rubular: http://rubular.com/r/gitvf0YWH4
-        SingleUpperCaseLetterRule = Rule.new(/(?<=\s[A-Z])\.(?=\s)/, '∯')
+        SingleUpperCaseLetterRule = Rule.new(/(?<=\s[A-Z])\.(?=,?\s)/, '∯')
 
         All = [
           SingleUpperCaseLetterAtStartOfLineRule,

--- a/spec/pragmatic_segmenter/languages/chinese_spec.rb
+++ b/spec/pragmatic_segmenter/languages/chinese_spec.rb
@@ -7,5 +7,10 @@ RSpec.describe PragmaticSegmenter::Languages::Chinese, '(zh)' do
       ps = PragmaticSegmenter::Segmenter.new(text: "安永已聯繫周怡安親屬，協助辦理簽證相關事宜，周怡安家屬1月1日晚間搭乘東方航空班機抵達上海，他們步入入境大廳時神情落寞、不發一語。周怡安來自台中，去年剛從元智大學畢業，同年9月加入安永。", language: 'zh')
       expect(ps.segment).to eq(["安永已聯繫周怡安親屬，協助辦理簽證相關事宜，周怡安家屬1月1日晚間搭乘東方航空班機抵達上海，他們步入入境大廳時神情落寞、不發一語。", "周怡安來自台中，去年剛從元智大學畢業，同年9月加入安永。"])
     end
+
+    it 'correctly segments text #002' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "我们明天一起去看《摔跤吧！爸爸》好吗？好！", language: 'zh')
+      expect(ps.segment).to eq(["我们明天一起去看《摔跤吧！爸爸》好吗？", "好！"])
+    end
   end
 end

--- a/spec/pragmatic_segmenter/languages/english_spec.rb
+++ b/spec/pragmatic_segmenter/languages/english_spec.rb
@@ -1416,5 +1416,10 @@ RSpec.describe PragmaticSegmenter::Languages::English, "(en)" do
       ps = PragmaticSegmenter::Segmenter.new(text: "Unlike the abbreviations i.e. and e.g., viz. is used to indicate a detailed description of something stated before.")
       expect(ps.segment).to eq(["Unlike the abbreviations i.e. and e.g., viz. is used to indicate a detailed description of something stated before."])
     end
+
+    it 'correctly segmentes text #120' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "For example, ‘dragonswort… is said that it should be grown in dragon’s blood. It grows at the tops of mountains where there are groves of trees, chiefly in holy places and in the country that is called Apulia’ (translated by Anne Van Arsdall, in Medieval Herbal Remedies: The Old English Herbarium and Anglo-Saxon Medicine p. 154). The Herbal also includes lore about other plants, such as the mandrake.")
+      expect(ps.segment).to eq(["For example, ‘dragonswort… is said that it should be grown in dragon’s blood. It grows at the tops of mountains where there are groves of trees, chiefly in holy places and in the country that is called Apulia’ (translated by Anne Van Arsdall, in Medieval Herbal Remedies: The Old English Herbarium and Anglo-Saxon Medicine p. 154).", "The Herbal also includes lore about other plants, such as the mandrake."])
+    end
   end
 end

--- a/spec/pragmatic_segmenter/languages/english_spec.rb
+++ b/spec/pragmatic_segmenter/languages/english_spec.rb
@@ -1417,9 +1417,14 @@ RSpec.describe PragmaticSegmenter::Languages::English, "(en)" do
       expect(ps.segment).to eq(["Unlike the abbreviations i.e. and e.g., viz. is used to indicate a detailed description of something stated before."])
     end
 
-    it 'correctly segmentes text #120' do
+    it 'correctly segments text #120' do
       ps = PragmaticSegmenter::Segmenter.new(text: "For example, ‘dragonswort… is said that it should be grown in dragon’s blood. It grows at the tops of mountains where there are groves of trees, chiefly in holy places and in the country that is called Apulia’ (translated by Anne Van Arsdall, in Medieval Herbal Remedies: The Old English Herbarium and Anglo-Saxon Medicine p. 154). The Herbal also includes lore about other plants, such as the mandrake.")
       expect(ps.segment).to eq(["For example, ‘dragonswort… is said that it should be grown in dragon’s blood. It grows at the tops of mountains where there are groves of trees, chiefly in holy places and in the country that is called Apulia’ (translated by Anne Van Arsdall, in Medieval Herbal Remedies: The Old English Herbarium and Anglo-Saxon Medicine p. 154).", "The Herbal also includes lore about other plants, such as the mandrake."])
+    end
+
+    it 'correctly segments text #121' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Here’s the - ahem - official citation: Baker, C., Anderson, Kenneth, Martin, James, & Palen, Leysia. Modeling Open Source Software Communities, ProQuest Dissertations and Theses.")
+      expect(ps.segment).to eq(["Here’s the - ahem - official citation: Baker, C., Anderson, Kenneth, Martin, James, & Palen, Leysia.", "Modeling Open Source Software Communities, ProQuest Dissertations and Theses."])
     end
   end
 end


### PR DESCRIPTION
Adds support for the following cases:

- The text uses slanted single quotes to present a quotation: ‘
- The text contains a single character abbreviation as part of a list: Some names, Baker B., Name 2, etc.
- The Chinese book quotes in issue #35 

I'm not sure if the 2 regexes for chinese book quotes should instead be moved into the chinese language instead? There are other types of quotes as well that may need inclusion: https://chinese.stackexchange.com/questions/517/when-are-and-and-other-brackets-used