### PR TITLE
Feature/file formats

### DIFF
--- a/lib/pragmatic_segmenter/languages/common.rb
+++ b/lib/pragmatic_segmenter/languages/common.rb
@@ -24,6 +24,8 @@ module PragmaticSegmenter
       # Rubular: http://rubular.com/r/G2opjedIm9
       GeoLocationRule = Rule.new(/(?<=[a-zA-z]°)\.(?=\s*\d+)/, '∯')
 
+      FileFormatRule = Rule.new(/(?<=\s)\.(?=(jpe?g|png|gif|tiff?|pdf|ps|docx?|xlsx?|svg|bmp|tga|exif|odt|html?|txt|rtf|bat|sxw|xml|zip|exe|msi|blend|wmv|mp[34]|pptx?|flac|rb|cpp|cs|js)\s)/, '∯')
+
       SingleNewLineRule = Rule.new(/\n/, 'ȹ')
 
       module DoublePunctuationRules

--- a/lib/pragmatic_segmenter/languages/common/numbers.rb
+++ b/lib/pragmatic_segmenter/languages/common/numbers.rb
@@ -47,6 +47,8 @@ module PragmaticSegmenter
       # Rubular: http://rubular.com/r/mQ8Es9bxtk
       CONTINUOUS_PUNCTUATION_REGEX = /(?<=\S)(!|\?){3,}(?=(\s|\z|$))/
 
+      NUMBERED_REFERENCE_REGEX = /(?<=[^\d\s])(\.|∯)((\[(\d{1,3},?\s?-?\s?)*\b\d{1,3}\])+|((\d{1,3}\s?)*\d{1,3}))(\s)(?=[A-Z])/
+
       # Rubular: http://rubular.com/r/yqa4Rit8EY
       PossessiveAbbreviationRule = Rule.new(/\.(?='s\s)|\.(?='s$)|\.(?='s\z)/, '∯')
 

--- a/lib/pragmatic_segmenter/processor.rb
+++ b/lib/pragmatic_segmenter/processor.rb
@@ -23,6 +23,7 @@ module PragmaticSegmenter
       replace_abbreviations
       replace_numbers
       replace_continuous_punctuation
+      replace_periods_before_numeric_references
       @text.apply(@language::Abbreviations::WithMultiplePeriodsAndEmailRule)
       @text.apply(@language::GeoLocationRule)
       @text.apply(@language::FileFormatRule)
@@ -67,6 +68,10 @@ module PragmaticSegmenter
       @text.gsub!(@language::CONTINUOUS_PUNCTUATION_REGEX) do |match|
         match.gsub(/!/, '&ᓴ&').gsub(/\?/, '&ᓷ&')
       end
+    end
+
+    def replace_periods_before_numeric_references
+      @text.gsub!(@language::NUMBERED_REFERENCE_REGEX, "∯\\2\r\\7")
     end
 
     def consecutive_underscore?(txt)

--- a/lib/pragmatic_segmenter/processor.rb
+++ b/lib/pragmatic_segmenter/processor.rb
@@ -25,6 +25,7 @@ module PragmaticSegmenter
       replace_continuous_punctuation
       @text.apply(@language::Abbreviations::WithMultiplePeriodsAndEmailRule)
       @text.apply(@language::GeoLocationRule)
+      @text.apply(@language::FileFormatRule)
       split_into_segments
     end
 

--- a/spec/pragmatic_segmenter/languages/english_spec.rb
+++ b/spec/pragmatic_segmenter/languages/english_spec.rb
@@ -1431,5 +1431,30 @@ RSpec.describe PragmaticSegmenter::Languages::English, "(en)" do
       ps = PragmaticSegmenter::Segmenter.new(text: "These include images of various modes of transport and members of the team, all available in .jpeg format. Images can be downloaded from our website. We also offer archives as .zip files.")
       expect(ps.segment).to eq(["These include images of various modes of transport and members of the team, all available in .jpeg format.", "Images can be downloaded from our website.", "We also offer archives as .zip files."])
     end
+
+    it 'correctly segments text #123' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Saint Maximus (died 250) is a Christian saint and martyr.[1] The emperor Decius published a decree ordering the veneration of busts of the deified emperors.")
+      expect(ps.segment).to eq(["Saint Maximus (died 250) is a Christian saint and martyr.[1]", "The emperor Decius published a decree ordering the veneration of busts of the deified emperors."])
+    end
+
+    it 'correctly segments text #124' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Differing agendas can potentially create an understanding gap in a consultation.11 12 Take the example of one of the most common presentations in ill health: the common cold.")
+      expect(ps.segment).to eq(["Differing agendas can potentially create an understanding gap in a consultation.11 12", "Take the example of one of the most common presentations in ill health: the common cold."])
+    end
+
+    it 'correctly segments text #125' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Daniel Kahneman popularised the concept of fast and slow thinking: the distinction between instinctive (type 1 thinking) and reflective, analytical cognition (type 2).10 This model relates to doctors achieving a balance between efficiency and effectiveness.")
+      expect(ps.segment).to eq(["Daniel Kahneman popularised the concept of fast and slow thinking: the distinction between instinctive (type 1 thinking) and reflective, analytical cognition (type 2).10", "This model relates to doctors achieving a balance between efficiency and effectiveness."])
+    end
+
+    it 'correctly segments text #126' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Its traditional use[1] is well documented in the ethnobotanical literature [2–11]. Leaves, buds, tar and essential oils are used to treat a wide spectrum of diseases.")
+      expect(ps.segment).to eq(["Its traditional use[1] is well documented in the ethnobotanical literature [2–11].", "Leaves, buds, tar and essential oils are used to treat a wide spectrum of diseases."])
+    end
+
+    it 'correctly segments text #127' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "Thus increasing the desire for political reform both in Lancashire and in the country at large.[7][8] This was a serious misdemeanour,[16] encouraging them to declare the assembly illegal as soon as it was announced on 31 July.[17][18] The radicals sought a second opinion on the meeting's legality.")
+      expect(ps.segment).to eq(["Thus increasing the desire for political reform both in Lancashire and in the country at large.[7][8]", "This was a serious misdemeanour,[16] encouraging them to declare the assembly illegal as soon as it was announced on 31 July.[17][18]", "The radicals sought a second opinion on the meeting's legality."])
+    end
   end
 end

--- a/spec/pragmatic_segmenter/languages/english_spec.rb
+++ b/spec/pragmatic_segmenter/languages/english_spec.rb
@@ -1426,5 +1426,10 @@ RSpec.describe PragmaticSegmenter::Languages::English, "(en)" do
       ps = PragmaticSegmenter::Segmenter.new(text: "Here’s the - ahem - official citation: Baker, C., Anderson, Kenneth, Martin, James, & Palen, Leysia. Modeling Open Source Software Communities, ProQuest Dissertations and Theses.")
       expect(ps.segment).to eq(["Here’s the - ahem - official citation: Baker, C., Anderson, Kenneth, Martin, James, & Palen, Leysia.", "Modeling Open Source Software Communities, ProQuest Dissertations and Theses."])
     end
+
+    it 'correctly segments text #122' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "These include images of various modes of transport and members of the team, all available in .jpeg format. Images can be downloaded from our website. We also offer archives as .zip files.")
+      expect(ps.segment).to eq(["These include images of various modes of transport and members of the team, all available in .jpeg format.", "Images can be downloaded from our website.", "We also offer archives as .zip files."])
+    end
   end
 end

--- a/spec/pragmatic_segmenter/languages/english_spec.rb
+++ b/spec/pragmatic_segmenter/languages/english_spec.rb
@@ -1456,5 +1456,11 @@ RSpec.describe PragmaticSegmenter::Languages::English, "(en)" do
       ps = PragmaticSegmenter::Segmenter.new(text: "Thus increasing the desire for political reform both in Lancashire and in the country at large.[7][8] This was a serious misdemeanour,[16] encouraging them to declare the assembly illegal as soon as it was announced on 31 July.[17][18] The radicals sought a second opinion on the meeting's legality.")
       expect(ps.segment).to eq(["Thus increasing the desire for political reform both in Lancashire and in the country at large.[7][8]", "This was a serious misdemeanour,[16] encouraging them to declare the assembly illegal as soon as it was announced on 31 July.[17][18]", "The radicals sought a second opinion on the meeting's legality."])
     end
+
+    it 'correctly segments text #128' do
+      ps = PragmaticSegmenter::Segmenter.new(text: "The table in (4) is a sample from the Wall Street Journal (1987).1 According to the distribution all the pairs given in (4) count as candidates for abbreviations.")
+      expect(ps.segment).to eq([ "The table in (4) is a sample from the Wall Street Journal (1987).1", "According to the distribution all the pairs given in (4) count as candidates for abbreviations."])
+    
+    end
   end
 end


### PR DESCRIPTION
This commit is primarily aimed at proper segmentation for text following the Wikipedia style of references, for example:

    "Some sentence which is backed up by a citation.[5]"

The majority of academic papers instead use a square bracketed reference prior to the period:

    "A sentence from a very important research paper [1, 2, 3]."

But some other papers use a superscript digit following the period:

    "This was backed up by earlier research.1"

Currently this would segment into something like:

input: "```Some sentence followed by a citation.[1] Further to this earlier research we found the following."```
output: ```[ "Some sentence followed by a citation.", "[1] Further to this earlier research we found the following." ]```
output (following change):  ```[ "Some sentence followed by a citation.[1]", "Further to this earlier research we found the following." ]```

The supported formats for these numeric references are:

```
.[1]
.[1,2]
.[1, 2]
.[1-2]
.1
.[5][7]
.10 11
```

Where the number can be from 0-999.

Let me know if this is something you had already considered but rejected for other reasons and feel free to close the PR if so.

It also adds support for common file formats in sentences, such as:

    We have downloaded the required cat .gif images to store.

