### PR TITLE
Refactor for Ruby 3.0 compatibility

### DIFF
--- a/lib/pragmatic_segmenter/abbreviation_replacer.rb
+++ b/lib/pragmatic_segmenter/abbreviation_replacer.rb
@@ -10,18 +10,19 @@ module PragmaticSegmenter
 
     attr_reader :text
     def initialize(text:, language: )
-      @text = Text.new(text)
+      @text = text.dup
       @language = language
     end
 
     def replace
-      @text.apply(@language::PossessiveAbbreviationRule,
+      Rule.apply(@text,
+        @language::PossessiveAbbreviationRule,
         @language::KommanditgesellschaftRule,
         @language::SingleLetterAbbreviationRules::All)
 
       @text = search_for_abbreviations_in_string(@text)
       @text = replace_multi_period_abbreviations(@text)
-      @text.apply(@language::AmPmRules::All)
+      Rule.apply(@text, @language::AmPmRules::All)
       replace_abbreviation_as_sentence_boundary(@text)
     end
 

--- a/lib/pragmatic_segmenter/cleaner.rb
+++ b/lib/pragmatic_segmenter/cleaner.rb
@@ -11,7 +11,7 @@ module PragmaticSegmenter
 
     attr_reader :text, :doc_type
     def initialize(text:, doc_type: nil, language: Languages::Common)
-      @text = Text.new(text)
+      @text = text.dup
       @doc_type = doc_type
       @language = language
     end
@@ -37,10 +37,10 @@ module PragmaticSegmenter
       replace_newlines
       replace_escaped_newlines
 
-      @text.apply(HTML::All)
+      Rule.apply(@text, HTML::All)
 
       replace_punctuation_in_brackets
-      @text.apply(InlineFormattingRule)
+      Rule.apply(@text, InlineFormattingRule)
       clean_quotations
       clean_table_of_contents
       check_for_no_space_in_between_sentences
@@ -72,7 +72,7 @@ module PragmaticSegmenter
       if word =~ regex
         unless URL_EMAIL_KEYWORDS.any? { |web| word =~ /#{web}/ }
           unless abbreviations.any? { |abbr| word =~ /#{abbr}/i }
-            new_word = word.dup.apply(rule)
+            new_word = Rule.apply(word.dup, rule)
             txt.gsub!(/#{Regexp.escape(word)}/, new_word)
           end
         end
@@ -92,45 +92,45 @@ module PragmaticSegmenter
     end
 
     def remove_newline_in_middle_of_word
-      @text.apply NewLineInMiddleOfWordRule
+      Rule.apply @text, NewLineInMiddleOfWordRule
     end
 
     def replace_escaped_newlines
-      @text.apply EscapedNewLineRule, EscapedCarriageReturnRule,
+      Rule.apply @text, EscapedNewLineRule, EscapedCarriageReturnRule,
         TypoEscapedNewLineRule, TypoEscapedCarriageReturnRule
     end
 
     def replace_double_newlines
-      @text.apply DoubleNewLineWithSpaceRule, DoubleNewLineRule
+      Rule.apply @text, DoubleNewLineWithSpaceRule, DoubleNewLineRule
     end
 
     def replace_newlines
       if doc_type.eql?('pdf')
         remove_pdf_line_breaks
       else
-        @text.apply NewLineFollowedByPeriodRule,
+        Rule.apply @text, NewLineFollowedByPeriodRule,
           ReplaceNewlineWithCarriageReturnRule
       end
     end
 
     def remove_pdf_line_breaks
-      @text.apply NewLineFollowedByBulletRule,
+      Rule.apply @text, NewLineFollowedByBulletRule,
 
         PDF::NewLineInMiddleOfSentenceRule,
         PDF::NewLineInMiddleOfSentenceNoSpacesRule
     end
 
     def clean_quotations
-      @text.apply QuotationsFirstRule, QuotationsSecondRule
+      Rule.apply @text, QuotationsFirstRule, QuotationsSecondRule
     end
 
     def clean_table_of_contents
-      @text.apply TableOfContentsRule, ConsecutivePeriodsRule,
+      Rule.apply @text, TableOfContentsRule, ConsecutivePeriodsRule,
         ConsecutiveForwardSlashRule
     end
 
     def clean_consecutive_characters
-      @text.apply ConsecutivePeriodsRule, ConsecutiveForwardSlashRule
+      Rule.apply @text, ConsecutivePeriodsRule, ConsecutiveForwardSlashRule
     end
   end
 end

--- a/lib/pragmatic_segmenter/languages/deutsch.rb
+++ b/lib/pragmatic_segmenter/languages/deutsch.rb
@@ -47,7 +47,7 @@ module PragmaticSegmenter
         private
 
         def replace_numbers
-          @text.apply Numbers::All
+          Rule.apply @text, Numbers::All
 
           replace_period_in_deutsch_dates
         end
@@ -68,7 +68,8 @@ module PragmaticSegmenter
         ).freeze
 
         def replace
-          @text = text.apply(
+          @text = Rule.apply(
+            text,
             @language::PossessiveAbbreviationRule,
             @language::SingleLetterAbbreviationRules::All,
             SingleLowerCaseLetterRule,
@@ -76,7 +77,7 @@ module PragmaticSegmenter
 
           @text = search_for_abbreviations_in_string(@text)
           @text = replace_multi_period_abbreviations(@text)
-          @text.apply(Languages::Common::AmPmRules::All)
+          Rule.apply(@text, Languages::Common::AmPmRules::All)
           replace_abbreviation_as_sentence_boundary(@text)
         end
 

--- a/lib/pragmatic_segmenter/languages/japanese.rb
+++ b/lib/pragmatic_segmenter/languages/japanese.rb
@@ -17,7 +17,7 @@ module PragmaticSegmenter
         private
 
         def remove_newline_in_middle_of_word
-          @text.apply NewLineInMiddleOfWordRule
+          Rule.apply @text, NewLineInMiddleOfWordRule
         end
       end
 

--- a/lib/pragmatic_segmenter/languages/kazakh.rb
+++ b/lib/pragmatic_segmenter/languages/kazakh.rb
@@ -23,7 +23,7 @@ module PragmaticSegmenter
 
         def between_punctuation(txt)
           super(txt)
-          txt.apply(QuestionMarkFollowedByDashLowercaseRule, ExclamationMarkFollowedByDashLowercaseRule)
+          Rule.apply(txt, QuestionMarkFollowedByDashLowercaseRule, ExclamationMarkFollowedByDashLowercaseRule)
         end
       end
 
@@ -35,7 +35,7 @@ module PragmaticSegmenter
 
         def replace
           super
-          @text.apply(SingleUpperCaseCyrillicLetterAtStartOfLineRule, SingleUpperCaseCyrillicLetterRule)
+          Rule.apply(@text, SingleUpperCaseCyrillicLetterAtStartOfLineRule, SingleUpperCaseCyrillicLetterRule)
         end
       end
     end

--- a/lib/pragmatic_segmenter/list.rb
+++ b/lib/pragmatic_segmenter/list.rb
@@ -48,7 +48,7 @@ module PragmaticSegmenter
 
     attr_reader :text
     def initialize(text:)
-      @text = Text.new(text)
+      @text = text.dup
     end
 
     def add_line_break
@@ -68,13 +68,13 @@ module PragmaticSegmenter
     def format_numbered_list_with_parens
       replace_parens_in_numbered_list
       add_line_breaks_for_numbered_list_with_parens
-      @text.apply(ListMarkerRule)
+      Rule.apply(@text, ListMarkerRule)
     end
 
     def format_numbered_list_with_periods
       replace_periods_in_numbered_list
       add_line_breaks_for_numbered_list_with_periods
-      @text.apply(SubstituteListPeriodRule)
+      Rule.apply(@text, SubstituteListPeriodRule)
     end
 
     def format_alphabetical_lists
@@ -93,7 +93,7 @@ module PragmaticSegmenter
 
     def add_line_breaks_for_numbered_list_with_periods
       if @text.include?('♨') && @text !~ /♨.+\n.+♨|♨.+\r.+♨/ && @text !~ /for\s\d{1,2}♨\s[a-z]/
-        @text.apply(SpaceBetweenListItemsFirstRule, SpaceBetweenListItemsSecondRule)
+        Rule.apply(@text, SpaceBetweenListItemsFirstRule, SpaceBetweenListItemsSecondRule)
       end
     end
 
@@ -105,7 +105,7 @@ module PragmaticSegmenter
 
     def add_line_breaks_for_numbered_list_with_parens
       if @text.include?('☝') && @text !~ /☝.+\n.+☝|☝.+\r.+☝/
-        @text.apply(SpaceBetweenListItemsThirdRule)
+        Rule.apply(@text, SpaceBetweenListItemsThirdRule)
       end
     end
 

--- a/lib/pragmatic_segmenter/processor.rb
+++ b/lib/pragmatic_segmenter/processor.rb
@@ -24,9 +24,9 @@ module PragmaticSegmenter
       replace_numbers
       replace_continuous_punctuation
       replace_periods_before_numeric_references
-      @text.apply(@language::Abbreviations::WithMultiplePeriodsAndEmailRule)
-      @text.apply(@language::GeoLocationRule)
-      @text.apply(@language::FileFormatRule)
+      Rule.apply(@text, @language::Abbreviations::WithMultiplePeriodsAndEmailRule)
+      Rule.apply(@text, @language::GeoLocationRule)
+      Rule.apply(@text, @language::FileFormatRule)
       split_into_segments
     end
 
@@ -34,18 +34,19 @@ module PragmaticSegmenter
 
     def split_into_segments
       check_for_parens_between_quotes(@text).split("\r")
-         .map! { |segment| segment.apply(@language::SingleNewLineRule, @language::EllipsisRules::All) }
+         .map! { |segment| Rule.apply(segment, @language::SingleNewLineRule, @language::EllipsisRules::All) }
          .map { |segment| check_for_punctuation(segment) }.flatten
-         .map! { |segment| segment.apply(@language::SubSymbolsRules::All) }
+         .map! { |segment| Rule.apply(segment, @language::SubSymbolsRules::All) }
          .map { |segment| post_process_segments(segment) }
          .flatten.compact.delete_if(&:empty?)
-         .map! { |segment| segment.apply(@language::SubSingleQuoteRule) }
+         .map! { |segment| Rule.apply(segment, @language::SubSingleQuoteRule) }
     end
 
     def post_process_segments(txt)
       return txt if txt.length < 2 && txt =~ /\A[a-zA-Z]*\Z/
       return if consecutive_underscore?(txt) || txt.length < 2
-      txt.apply(
+      Rule.apply(
+        txt,
         @language::ReinsertEllipsisRules::All,
         @language::ExtraWhiteSpaceRule
       )
@@ -91,7 +92,8 @@ module PragmaticSegmenter
       txt << 'ȸ' unless @language::Punctuations.any? { |p| txt[-1].include?(p) }
       ExclamationWords.apply_rules(txt)
       between_punctuation(txt)
-      txt = txt.apply(
+      txt = Rule.apply(
+        txt,
         @language::DoublePunctuationRules::All,
         @language::QuestionMarkInQuotationRule,
         @language::ExclamationPointRules::All
@@ -101,7 +103,7 @@ module PragmaticSegmenter
     end
 
     def replace_numbers
-      @text.apply @language::Numbers::All
+      Rule.apply @text, @language::Numbers::All
     end
 
     def abbreviations_replacer
@@ -129,8 +131,8 @@ module PragmaticSegmenter
     end
 
     def sentence_boundary_punctuation(txt)
-      txt = txt.apply @language::ReplaceColonBetweenNumbersRule if defined? @language::ReplaceColonBetweenNumbersRule
-      txt = txt.apply @language::ReplaceNonSentenceBoundaryCommaRule if defined? @language::ReplaceNonSentenceBoundaryCommaRule
+      txt = Rule.apply txt, @language::ReplaceColonBetweenNumbersRule if defined? @language::ReplaceColonBetweenNumbersRule
+      txt = Rule.apply txt, @language::ReplaceNonSentenceBoundaryCommaRule if defined? @language::ReplaceNonSentenceBoundaryCommaRule
 
       txt.scan(@language::SENTENCE_BOUNDARY_REGEX)
     end

--- a/lib/pragmatic_segmenter/punctuation_replacer.rb
+++ b/lib/pragmatic_segmenter/punctuation_replacer.rb
@@ -45,9 +45,9 @@ module PragmaticSegmenter
 
     def replace_punctuation(array)
       return if !array || array.empty?
-      @text.apply(Rules::EscapeRegexReservedCharacters::All)
+      Rule.apply(@text, Rules::EscapeRegexReservedCharacters::All)
       array.each do |a|
-        a.apply(Rules::EscapeRegexReservedCharacters::All)
+        Rule.apply(a, Rules::EscapeRegexReservedCharacters::All)
         sub = sub_characters(a, '.', '∯')
         sub_1 = sub_characters(sub, '。', '&ᓰ&')
         sub_2 = sub_characters(sub_1, '．', '&ᓱ&')
@@ -59,7 +59,7 @@ module PragmaticSegmenter
           sub_7 = sub_characters(sub_6, "'", '&⎋&')
         end
       end
-      @text.apply(Rules::SubEscapedRegexReservedCharacters::All)
+      Rule.apply(@text, Rules::SubEscapedRegexReservedCharacters::All)
     end
 
     def sub_characters(string, char_a, char_b)

--- a/lib/pragmatic_segmenter/types.rb
+++ b/lib/pragmatic_segmenter/types.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module PragmaticSegmenter
-  Rule = Struct.new(:pattern, :replacement)
-
-  class Text < String
-    def apply(*rules)
-      rules.flatten.each do |rule|
-        self.gsub!(rule.pattern, rule.replacement)
+  class Rule < Struct.new(:pattern, :replacement)
+    class << self
+      def apply(str, *rules)
+        rules.flatten.each do |rule|
+          str.gsub!(rule.pattern, rule.replacement)
+        end
+        str
       end
-      self
     end
   end
 end

--- a/pragmatic_segmenter.gemspec
+++ b/pragmatic_segmenter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "unicode"
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "stackprof"


### PR DESCRIPTION
Closes #67 

Internally, the segmenter uses `PragmaticSegmenter::Text`, a subclass of Ruby `String`, but as of Ruby 3, calling String methods no longer returns the subclass. This PR refactors code so that it doesn't depend on the subclass.

## Changes

* Move helper method `Text#apply` to `Rule#apply`, which takes a string and applies a number of rules to it
* Replace `Text` with standard Ruby `String`
* Relax constraint on bundler version