### PR TITLE
#78: Fixed issues with catastrophic backtracking when detecting numbered references

### DIFF
--- a/lib/pragmatic_segmenter/languages/common/numbers.rb
+++ b/lib/pragmatic_segmenter/languages/common/numbers.rb
@@ -47,7 +47,7 @@ module PragmaticSegmenter
       # Rubular: http://rubular.com/r/mQ8Es9bxtk
       CONTINUOUS_PUNCTUATION_REGEX = /(?<=\S)(!|\?){3,}(?=(\s|\z|$))/
 
-      NUMBERED_REFERENCE_REGEX = /(?<=[^\d\s])(\.|∯)((\[(\d{1,3},?\s?-?\s?)*\b\d{1,3}\])+|((\d{1,3}\s?)*\d{1,3}))(\s)(?=[A-Z])/
+      NUMBERED_REFERENCE_REGEX = /(?<=[^\d\s])(\.|∯)((\[(\d{1,3},?\s?-?\s?)?\b\d{1,3}\])+|((\d{1,3}\s?){0,3}\d{1,3}))(\s)(?=[A-Z])/
 
       # Rubular: http://rubular.com/r/yqa4Rit8EY
       PossessiveAbbreviationRule = Rule.new(/\.(?='s\s)|\.(?='s$)|\.(?='s\z)/, '∯')


### PR DESCRIPTION
This pull requests solves the problems with catastrophic backtracking that are described in issue #78.

Although the regular expression is now somewhat more restrictive, I think it will cover the vast majority of numbered references that are used in practice. 